### PR TITLE
Accept Both Capital and Small Letter Username

### DIFF
--- a/server.js
+++ b/server.js
@@ -14,7 +14,7 @@ app.get("/example-data", (request, response) => {
 });
 
 app.ws("/user", function(ws, req) {
-  const name = req.query.name;
+  const name = req.query.name.toLowerCase();
   devApi(name, ws);
 });
 


### PR DESCRIPTION
Accepted username is now case insensitive
Check Issue #8 for reference

**Changes**
When extracting the parameters of the request, the username is converted to lowercase.

